### PR TITLE
fix: prevent horizontal scroll on mobile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -66,7 +66,7 @@ function App() {
   }, [])
 
   return (
-    <div className="min-h-screen" style={{ backgroundColor: '#0e100f' }}>
+    <div className="min-h-screen overflow-x-hidden" style={{ backgroundColor: '#0e100f' }}>
       <AnimatePresence mode="wait">
         {isLoading && (
           <>

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -46,9 +46,9 @@ const Hero = () => {
             </div>
 
             {/* Hello Pill - Top-right of avatar, bottom edge aligned with avatar midline */}
-            <motion.div 
-              variants={itemVariants} 
-              className="absolute top-5 left-full ml-2"
+            <motion.div
+              variants={itemVariants}
+              className="absolute left-1/2 top-full mt-2 transform -translate-x-1/2 md:top-5 md:left-full md:ml-2 md:mt-0 md:translate-x-0"
             >
               <div className="rounded-full px-6 py-1.5" style={{ border: '1px solid #323228' }}>
                 <span className="text-base md:text-lg font-headline font-medium whitespace-nowrap" style={{ color: '#fffce4' }}>Hello, I'm Mursaleen</span>

--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,7 @@
 @layer base {
   html {
     scroll-behavior: auto; /* Reset to default for keyboard navigation */
+    overflow-x: hidden; /* Prevent horizontal scrolling */
   }
   
   body {
@@ -12,6 +13,10 @@
     background-color: #0e100f;
     color: #fffce4;
     overflow-x: hidden;
+  }
+
+  #root {
+    overflow-x: hidden; /* Ensure root container doesn't overflow */
   }
 
   /* Custom Scrolling Behavior */


### PR DESCRIPTION
## Summary
- prevent horizontal page scrolling by hiding overflow on root elements
- ignore node_modules to keep repository clean

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689166ed20e08333a6e306185dd5084e